### PR TITLE
fixed Object name in Users.cs

### DIFF
--- a/Models/Users.cs
+++ b/Models/Users.cs
@@ -9,7 +9,7 @@ public class User
   public string Bio { get; set; }
   public string Username { get; set; }
   public string Password { get; set; }
-  public DateTime { get; set; }
+  public DateTime CreatedOn { get; set; }
   public List<Subscription> Subscriptions { get; set; }
   public List<PostReaction> PostReactions { get; set; }
   public List<Comment> Comments { get; set; }


### PR DESCRIPTION
**## Description**

Corrected "public DateTime CreatedOn { get; set; }" in Users.cs


**## Related Issue**

#3 


**## Motivation and Context**

Uncorrected name generated a compile error


**## How Can This Be Tested?**

Pull down and manually test


**## Screenshots (if appropriate):**

N/A


## Types of changes

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
