### PR TITLE
Endpoint for submitting POST requests to /login

### DIFF
--- a/Models/LoginRequest.cs
+++ b/Models/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace RAREAPI.Models;
+
+public class LoginRequest
+{
+    public string Username { get; set; }
+    public string Password { get; set; }
+}

--- a/Models/Posts.cs
+++ b/Models/Posts.cs
@@ -7,7 +7,7 @@ public class Post
   public int Id { get; set; }
   public int UserId { get; set; }
   public string Title { get; set; }
-  public DateTime PublicationDate { get; set; }
+  public DateTime? PublicationDate { get; set; }
   public string Content { get; set; }
   public bool Approved { get; set; }
   public List<Comment> Comments { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -195,9 +195,15 @@ app.MapPost("/reactions", (Reaction reactionPayload) =>
 });
 app.MapPost("/login", (LoginRequest loginRequest) =>
 {
+    var userObj = users.FirstOrDefault(u => u.Username == loginRequest.Username && u.Password == loginRequest.Password);
     if (string.IsNullOrEmpty(loginRequest.Username) || string.IsNullOrEmpty(loginRequest.Password))
     {
-        return Results.BadRequest("Invalid login! Try again please.");
+        return Results.BadRequest("Nothing was entered. Try again.");
+    }
+
+    if (userObj.Username != loginRequest.Username && userObj.Password != loginRequest.Password)
+    {
+        return Results.BadRequest("Wrong username or password.");
     }
 
     var user = users.FirstOrDefault(user =>

--- a/Program.cs
+++ b/Program.cs
@@ -312,7 +312,12 @@ app.MapDelete("/postreactions/{id}", (int id) =>
 // GET
 app.MapGet("/posts", () =>
 {
-    return Results.Ok(posts);
+    var sortedByDateRecentFirst = posts
+        .Where(p => p.PublicationDate.HasValue)
+        .OrderBy(p => p.PublicationDate)
+        .Reverse()
+        .ToList();
+    return Results.Ok(sortedByDateRecentFirst);
 });
 
 app.MapGet("/posts/{id}", (int id) =>

--- a/Program.cs
+++ b/Program.cs
@@ -203,7 +203,12 @@ app.MapPost("/login", (LoginRequest loginRequest) =>
     var user = users.FirstOrDefault(user =>
         user.Username.Equals(loginRequest.Username, StringComparison.OrdinalIgnoreCase) &&
         user.Password == loginRequest.Password);
-    return Results.Ok(new { ResponseMessage = "Login successful!" });
+    return Results.Ok(new
+    {
+        ResponseMessage = "Login successful!",
+        Valid = true,
+        token = "Random token lol"
+    });
 });
 
 // GET ENDPOINTS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->
Added another route for submitting POST requests to /login. Had to do some research on adding Cors policy and how to add one to our web api. After that, I followed the instructions on #45 to create a new class file, add the required properties, and add some logic to the handler to validate the request before sending a success or failure response.

EDIT: Also pushed up a quick fix in Response.Ok for the `/login` POST endpoint that sends back to the client (the response) two additional properties - "Valid" and "token" as our frontend was expecting the two:
<img width="439" alt="Screenshot 2025-02-16 at 5 55 33 PM" src="https://github.com/user-attachments/assets/89c4badb-681b-4651-8fc7-80403678e4e2" />

The client now redirects the user to the root `/` route!

EDIT 2: Now sorting GET /posts by most recent to oldest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#45](https://github.com/noahcallen/RAREAPI/issues/45)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to submit a POST payload from Postman/Swagger/IDE tools to the `/login`  endpoint. This change is needed to send a response back to a client that confirms a login was successful or failed.

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
Pull down branch locally and test endpoint using whatever API testing tool you prefer.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
